### PR TITLE
Add a nice badge for the support chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Support Chat](https://matrix.to/#/#mx-puppet-bridge:sorunome.de) [![donate](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/Sorunome/donate)
+[![Support room on Matrix](https://img.shields.io/matrix/mx-puppet-discord:sorunome.de.svg?label=%23mx-puppet-discord%3Asorunome.de&logo=matrix&server_fqdn=sorunome.de)](https://matrix.to/#/#mx-puppet-discord:sorunome.de) [![donate](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/Sorunome/donate)
 
 # mx-puppet-discord
 This is a discord puppeting bridge for matrix. It only handles DMs. For a discord bridge for guilds, please see [matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord).


### PR DESCRIPTION
Adds a nicer link to the support chat with live user count and everything. Analogous to [what we do for Dendrite](https://github.com/matrix-org/dendrite).

Guest access will need to be allowed for the room before the user count can be shown.