### PR TITLE
Sample sample config to only allow users on a homeserver

### DIFF
--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -21,9 +21,9 @@ provisioning:
     # Allow a specific user
     #- "@user:server\\.com"
     # Allow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    - "@.*:yourserver\\.com"
     # Allow anyone
-    - ".*"
+    #- ".*"
   # Regex of Matrix IDs forbidden from using the puppet bridge
   blacklist:
     # Disallow a specific user


### PR DESCRIPTION
So we don't proliferate wide-open bridges by default.