### PR TITLE
Fill out all known sample config values with comments

### DIFF
--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -32,5 +32,39 @@ provisioning:
     #- "@.*:yourserver\\.com"
 
 database:
+  # Use Postgres as a database backend
+  # If set, will be used instead of SQLite3
+  # Connection string to connect to the Postgres instance
+  # with username "user", password "pass", host "localhost" and database name "dbname".
+  # Modify each value as necessary
+  #connString: "postgres://user:pass@localhost/dbname?sslmode=disable"
+  # Use SQLite3 as a database backend
   # The name of the database file
   filename: database.db
+
+logging:
+  # Log level of console output
+  # Allowed values starting with most verbose:
+  # silly, debug, verbose, info, warn, error
+  console: info
+  # Date and time formatting
+  lineDateFormat: MMM-D HH:mm:ss.SSS
+  # Logging files
+  # Log files are rotated daily by default
+  files:
+    # Log file path
+    - file: "bridge.log"
+      # Log level for this file
+      # Allowed values starting with most verbose:
+      # silly, debug, verbose, info, warn, error
+      level: info
+      # Date and time formatting
+      datePattern: YYYY-MM-DD
+      # Maximum number of logs to keep.
+      # This can be a number of files or number of days.
+      # If using days, add 'd' as a suffix
+      maxFiles: 14d
+      # Maximum size of the file after which it will rotate. This can be a
+      # number of bytes, or units of kb, mb, and gb. If using the units, add
+      # 'k', 'm', or 'g' as the suffix
+      maxSize: 50m


### PR DESCRIPTION
Adds all known config file options and what I believe to be their descriptions to the sample config file. Config options taken from here: https://github.com/Sorunome/mx-puppet-bridge/blob/master/src/config.ts

There are `enabled` and `disabled` arrays under the logging/files config option, but I'm not sure what they do: https://github.com/Sorunome/mx-puppet-bridge/blob/1c7f4f1440fcc0ddfb3c25314133ddd4f2fe2e4d/src/config.ts#L38-L39

They seem to have something to do with enabling/disabling mods(?): https://github.com/Sorunome/mx-puppet-bridge/blob/fbc3eeb57d79c36f9338500a103f93ffb5fe01e1/src/log.ts#L77-L82