### PR TITLE
refactor Dockerifle to use a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
+FROM node:latest AS builder
+
+WORKDIR /opt/mx-puppet-discord
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+
 FROM node:alpine
 
-COPY . /opt/mx-puppet-discord
-WORKDIR /opt/mx-puppet-discord
-RUN apk add --no-cache ca-certificates \
-	&& apk add --no-cache --virtual .build-deps git make gcc g++ python \
-	&& npm install \
-	&& npm run build \
-	&& apk del .build-deps
 VOLUME ["/data"]
+
+WORKDIR /opt/mx-puppet-discord
+
+COPY docker-run.sh ./
+COPY --from=builder /opt/mx-puppet-discord/node_modules/ ./node_modules/
+COPY --from=builder /opt/mx-puppet-discord/build/ ./build/
+
 ENTRYPOINT ["./docker-run.sh"]


### PR DESCRIPTION
also re-ordered some things for better caching

image size is down 15mb

build time for a src-only change is down from multiple minutes
(including fetching all dependencies and compiling sqlite) to
the time of a `npm run build`