### PR TITLE
use non-root users in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:latest AS builder
 
 WORKDIR /opt/mx-puppet-discord
+RUN adduser --disabled-password --gecos '' builder \
+ && chown builder:builder .
+USER builder
 
 COPY package.json package-lock.json ./
 RUN npm install
@@ -13,6 +16,8 @@ RUN npm run build
 FROM node:alpine
 
 VOLUME ["/data"]
+
+RUN adduser -D -g '' bridge
 
 WORKDIR /opt/mx-puppet-discord
 

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,20 +1,22 @@
 #!/bin/sh -e
 
+chown -R bridge:bridge /data
+
 if [ ! -f '/data/config.yaml' ]; then
 	echo 'No config found'
 	exit 1
 fi
 
 if [ ! -f '/data/discord-registration.yaml' ]; then
-	node '/opt/mx-puppet-discord/build/index.js' \
+    su -l bridge -c "/usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
             -c '/data/config.yaml' \
             -f '/data/discord-registration.yaml' \
-            -r
+            -r"
 
 	echo 'Registration generated.'
 	exit 0
 fi
 
-node '/opt/mx-puppet-discord/build/index.js' \
+su -l bridge -c "/usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
     -c '/data/config.yaml' \
-    -f '/data/discord-registration.yaml'
+    -f '/data/discord-registration.yaml'"


### PR DESCRIPTION
For building it is neccessary to use non-root, because otherwise the
prepack scripts for e.g. building the matrix-bot-sdk fork don't run.

For normal running it also makes sense to use a non-root user to limit
the permissions in case of a breach.

This commit adds the user via Dockerfile and switches to it
in the entrypoint via `su`. The latter enables us to chown /data,
in case it already contains files or otherwise has wrong permissions.