### PR TITLE
Adapt docker build for ansible deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM node:latest AS builder
 
 WORKDIR /opt/mx-puppet-discord
-RUN adduser --disabled-password --gecos '' builder \
- && chown builder:builder .
-
-USER builder
 
 COPY package.json package-lock.json ./
 RUN npm install
@@ -16,9 +12,8 @@ RUN npm run build
 
 FROM node:alpine
 
-VOLUME ["/data"]
-
-RUN adduser -D -g '' bridge
+VOLUME /data
+VOLUME /config
 
 WORKDIR /opt/mx-puppet-discord
 

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,22 +1,20 @@
 #!/bin/sh -e
 
-chown -R bridge:bridge /data
-
-if [ ! -f '/data/config.yaml' ]; then
+if [ ! -f '/config/config.yaml' ]; then
 	echo 'No config found'
+    echo
+    echo "Be sure to mount a config volume with \`-v /your/local/path:/config'."
 	exit 1
 fi
 
-if [ ! -f '/data/discord-registration.yaml' ]; then
-    su -l bridge -c "/usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
-            -c '/data/config.yaml' \
-            -f '/data/discord-registration.yaml' \
-            -r"
+args="$@"
 
-	echo 'Registration generated.'
-	exit 0
+if [ ! -f '/config/registration.yaml' ]; then
+	echo 'No registration found, generating now'
+    args="-r"
 fi
 
-su -l bridge -c "/usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
-    -c '/data/config.yaml' \
-    -f '/data/discord-registration.yaml'"
+exec /usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
+     -c '/config/config.yaml' \
+     -f '/config/registration.yaml' \
+     $args


### PR DESCRIPTION
This removes the hard-coded user and group assignment in the docker build to allow the user of the container to determine the user and group for the config and data directories.

This also adds a separate `/config` volume to match the other services in the ansible deployment playbook and the `docker-run.sh` script has been updated to use the new location.

This is a breaking change to the deployment of the docker image.

```
docker run --rm --user 1000:1000 -v /tmp/discord-test-config:/config -v /tmp/discord-test-data:/data dangersalad/mx-puppet-discord:no-user
```

^ This can be used to test the new setup (assuming your UID and GID match, also make the data dirs owned by that same user)