### PR TITLE
Add environment variables for paths in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN npm run build
 FROM node:alpine
 
 VOLUME /data
-VOLUME /config
+
+ENV CONFIG_PATH=/data/config.yaml \
+    REGISTRATION_PATH=/data/discord-registration.yaml
 
 WORKDIR /opt/mx-puppet-discord
 

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,20 +1,18 @@
 #!/bin/sh -e
 
-if [ ! -f '/config/config.yaml' ]; then
+if [ ! -f "$CONFIG_PATH" ]; then
 	echo 'No config found'
-    echo
-    echo "Be sure to mount a config volume with \`-v /your/local/path:/config'."
 	exit 1
 fi
 
 args="$@"
 
-if [ ! -f '/config/registration.yaml' ]; then
+if [ ! -f "$REGISTRATION_PATH" ]; then
 	echo 'No registration found, generating now'
-    args="-r"
+	args="-r"
 fi
 
 exec /usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
-     -c '/config/config.yaml' \
-     -f '/config/registration.yaml' \
+     -c "$CONFIG_PATH" \
+     -f "$REGISTRATION_PATH" \
      $args


### PR DESCRIPTION
This reverts the breaking path change in #51, but still allows users to define custom paths using the new environment variables.

Someone should make sure this actually works, since I didn't test it yet :D