### PR TITLE
drop privileges before running docker-run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM node:latest AS builder
 
 WORKDIR /opt/mx-puppet-discord
 
+# run build process as user in case of npm pre hooks
+# pre hooks are not executed while running as root
+RUN chown node:node /opt/mx-puppet-discord
+USER node
+
 COPY package.json package-lock.json ./
 RUN npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN npm run build
 FROM node:alpine
 
 VOLUME /data
-VOLUME /config
+
+ENV CONFIG_PATH=/data/config.yaml \
+    REGISTRATION_PATH=/data/discord-registration.yaml
 
 WORKDIR /opt/mx-puppet-discord
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ ENV CONFIG_PATH=/data/config.yaml \
     REGISTRATION_PATH=/data/discord-registration.yaml
 
 WORKDIR /opt/mx-puppet-discord
+# su-exec is used by docker-run.sh to drop privileges
+RUN apk add --no-cache su-exec
 
 COPY docker-run.sh ./
 COPY --from=builder /opt/mx-puppet-discord/node_modules/ ./node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,15 @@ VOLUME /data
 ENV CONFIG_PATH=/data/config.yaml \
     REGISTRATION_PATH=/data/discord-registration.yaml
 
-WORKDIR /opt/mx-puppet-discord
 # su-exec is used by docker-run.sh to drop privileges
 RUN apk add --no-cache su-exec
 
+WORKDIR /opt/mx-puppet-discord
 COPY docker-run.sh ./
 COPY --from=builder /opt/mx-puppet-discord/node_modules/ ./node_modules/
 COPY --from=builder /opt/mx-puppet-discord/build/ ./build/
 
-ENTRYPOINT ["./docker-run.sh"]
+# change workdir to /data so relative paths in the config.yaml
+# point to the persisten volume
+WORKDIR /data
+ENTRYPOINT ["/opt/mx-puppet-discord/docker-run.sh"]

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -12,7 +12,27 @@ if [ ! -f "$REGISTRATION_PATH" ]; then
 	args="-r"
 fi
 
-exec /usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
+
+# if no --uid is supplied, prepare files to drop privileges
+if [ "$(id -u)" = 0 ]; then
+	chown node:node /data
+
+	if find *.db > /dev/null 2>&1; then
+		# make sure sqlite files are writeable
+		chown node:node *.db
+	fi
+	if find *.log.* > /dev/null 2>&1; then
+		# make sure log files are writeable
+		chown node:node *.log.*
+	fi
+
+	su_exec='su-exec node:node'
+else
+	su_exec=''
+fi
+
+# $su_exec is used in case we have to drop the privileges
+exec $su_exec /usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
      -c "$CONFIG_PATH" \
      -f "$REGISTRATION_PATH" \
      $args

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,20 +1,18 @@
 #!/bin/sh -e
 
-if [ ! -f '/config/config.yaml' ]; then
+if [ ! -f "$CONFIG_PATH" ]; then
 	echo 'No config found'
-    echo
-    echo "Be sure to mount a config volume with \`-v /your/local/path:/config'."
 	exit 1
 fi
 
 args="$@"
 
-if [ ! -f '/config/registration.yaml' ]; then
+if [ ! -f "$REGISTRATION_PATH" ]; then
 	echo 'No registration found, generating now'
-    args="-r"
+	args="-r"
 fi
 
 exec /usr/local/bin/node '/opt/mx-puppet-discord/build/index.js' \
-     -c '/config/config.yaml' \
-     -f '/config/registration.yaml' \
+     -c "$CONFIG_PATH" \
+     -f "$REGISTRATION_PATH" \
      $args


### PR DESCRIPTION
This PR includes #52 and additionally also reverts to dropping privileges instead of running the bridge as root.

In contrast to the old behavior it is possible to specify a custom uid via `docker run --user` to circumvent the hardcoded user.

See https://matrix.to/#/!uOjvskgRfNgksdiArw:sorunome.de/$4pIRr1ypKnlyWvu9mehn7E8GHsdqUItiMB5peubEajI?via=sorunome.de&via=matrix.org&via=privacytools.io for a more detailed discussion about it