### PR TITLE
Sanitize nicknames to limit length to 80 bytes

### DIFF
--- a/src/matrix/MatrixEventHandler.ts
+++ b/src/matrix/MatrixEventHandler.ts
@@ -33,8 +33,9 @@ export class MatrixEventHandler {
 		}
 
 		if (asUser) {
-			var displayname = (new TextEncoder().encode(asUser.displayname))
-			asUser.displayname = (new TextDecoder().decode(displayname.slice(0, 80)))
+			const MAX_NAME_LENGTH = 80;
+			const displayname = (new TextEncoder().encode(asUser.displayname));
+			asUser.displayname = (new TextDecoder().decode(displayname.slice(0, MAX_NAME_LENGTH)));
 		}
 
 		const sendMsg = await this.app.matrix.parseMatrixMessage(room.puppetId, event.content);

--- a/src/matrix/MatrixEventHandler.ts
+++ b/src/matrix/MatrixEventHandler.ts
@@ -14,6 +14,7 @@ limitations under the License.
 import { IRemoteRoom, IMessageEvent, ISendingUser, IFileEvent, Util, Log } from "mx-puppet-bridge";
 import { App, IDiscordSendFile, MAXFILESIZE, AVATAR_SETTINGS } from "../app";
 import * as Discord from "better-discord.js";
+import { TextEncoder, TextDecoder } from "util";
 
 const log = new Log("DiscordPuppet:MatrixEventHandler");
 
@@ -29,6 +30,11 @@ export class MatrixEventHandler {
 		if (!chan) {
 			log.warn("Channel not found", room);
 			return;
+		}
+
+		if (asUser) {
+			var displayname = (new TextEncoder().encode(asUser.displayname))
+			asUser.displayname = (new TextDecoder().decode(displayname.slice(0, 80)))
 		}
 
 		const sendMsg = await this.app.matrix.parseMatrixMessage(room.puppetId, event.content);


### PR DESCRIPTION
Fixes #71 

* Truncates names longer than 80 bytes (for the Discord API, see #71)
* Does not check for names of length 0 (I can't envision a scenario where this happens)
* Does not handle Encoder/Decoder errors (though I couldn't produce any that should effect anything)

I can't imagine this will have a major performance impact, and I believe it'll catch every scenario.