### PR TITLE
Fix "EACCES" error with docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,11 @@ RUN wget -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sger
     wget -O glibc-2.32-r0.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk && \
     apk add glibc-2.32-r0.apk
 
+COPY package.json package-lock.json ./
+RUN chown node:node package.json package-lock.json
+
 USER node
 
-COPY package.json package-lock.json ./
 RUN npm install
 
 COPY tsconfig.json ./


### PR DESCRIPTION
I tried building the docker image but ended up with this error:

```
STEP 8: RUN npm install
npm notice 
npm notice New patch version of npm available! 7.0.3 -> 7.0.7
npm notice Changelog: https://github.com/npm/cli/releases/tag/v7.0.7
npm notice Run npm install -g npm@7.0.7 to update!
npm notice 
npm ERR! code EACCES
npm ERR! syscall open
npm ERR! path /opt/mx-puppet-discord/package-lock.json
npm ERR! errno -13
npm ERR! Error: EACCES: permission denied, open '/opt/mx-puppet-discord/package-lock.json'
npm ERR!  [Error: EACCES: permission denied, open '/opt/mx-puppet-discord/package-lock.json'] {
npm ERR!   errno: -13,
npm ERR!   code: 'EACCES',
npm ERR!   syscall: 'open',
npm ERR!   path: '/opt/mx-puppet-discord/package-lock.json'
npm ERR! }
npm ERR! 
npm ERR! The operation was rejected by your operating system.
npm ERR! It is likely you do not have the permissions to access this file as the current user
npm ERR! 
npm ERR! If you believe this might be a permissions issue, please double-check the
npm ERR! permissions of the file and its containing directories, or try running
npm ERR! the command again as root/Administrator.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/node/.npm/_logs/2020-11-03T22_04_38_072Z-debug.log
STEP 9: FROM node:alpine
Error: error building at STEP "RUN npm install": error while running runtime: exit status 243
```

I managed to fix this error with the change I propose in this PR, if you are interested!