### PR TITLE
Fix: Matrix to Discord mentions needed matrix-discord-parser 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -218,9 +218,9 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/react": {
-      "version": "16.9.49",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-      "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -650,9 +650,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "csstype": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+      "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
     },
     "cycle": {
       "version": "1.0.3",
@@ -1055,9 +1055,9 @@
       }
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "highlight.js": {
       "version": "9.18.3",
@@ -1312,15 +1312,15 @@
       }
     },
     "matrix-discord-parser": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/matrix-discord-parser/-/matrix-discord-parser-0.1.4.tgz",
-      "integrity": "sha512-slwMf3mJP3bcvFtzwbe7E3UP74y8EAKUgQ2MWthXsT7V/plaQQQdVwfAk/I5fePGpkcyWHBhF7Odn9mDK3OPLg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/matrix-discord-parser/-/matrix-discord-parser-0.1.5.tgz",
+      "integrity": "sha512-SilBNcNeJCrL6XEHVfbOhupNJICFdyFWfwv85Wtyh1Xxc0XPv4zK/gpEPogVeuKJD3TE0KT4iHq0nLgUJ8GBiQ==",
       "requires": {
         "discord-markdown": "git://github.com/Sorunome/discord-markdown.git#7958a03a952ed02cbd588b09eb04bc070b3a11f2",
         "escape-html": "^1.0.3",
         "got": "^11.6.0",
         "highlight.js": "^9.18.1",
-        "node-html-parser": "^1.2.15",
+        "node-html-parser": "^1.4.5",
         "unescape-html": "^1.1.0"
       }
     },
@@ -1536,11 +1536,11 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-html-parser": {
-      "version": "1.2.20",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.2.20.tgz",
-      "integrity": "sha512-1fUpYjAducDrrBSE0etRUV1tM+wSFTudmrslMXuk35wL/L29E7e1CLQn4CNzFLnqtYpmDlWhkD6VUloyHA0dwA==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.4.9.tgz",
+      "integrity": "sha512-UVcirFD1Bn0O+TSmloHeHqZZCxHjvtIeGdVdGMhyZ8/PWlEiZaZ5iJzR189yKZr8p0FXN58BUeC7RHRkf/KYGw==",
       "requires": {
-        "he": "1.1.1"
+        "he": "1.2.0"
       }
     },
     "node-pre-gyp": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "events": "^3.0.0",
     "expire-set": "^1.0.0",
     "js-yaml": "^3.13.1",
-    "matrix-discord-parser": "0.1.4",
+    "matrix-discord-parser": "0.1.5",
     "mime": "^2.4.4",
     "mx-puppet-bridge": "0.0.45-3",
     "path": "^0.12.7",


### PR DESCRIPTION
I noticed reactions didn't get parsed correctly. After a bit of digging I noticed the latest matrix-discord-parser is able to parse matrix messages, while is 0.1.4 not.