### PR TITLE
add category name to room name format vars

### DIFF
--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -129,6 +129,7 @@ namePatterns:
   #
   # name: name of the channel
   # guild: name of the guild
+  # category: name of the category if existant
   room: :name
 
   # Group names for bridged Discord servers

--- a/src/matrix/MatrixUtil.ts
+++ b/src/matrix/MatrixUtil.ts
@@ -169,6 +169,7 @@ export class MatrixUtil {
 			ret.nameVars = {
 				name: gchan.name,
 				guild: gchan.guild.name,
+				category: gchan.parent?.name,
 			};
 			ret.avatarUrl = gchan.guild.iconURL(AVATAR_SETTINGS);
 			ret.groupId = gchan.guild.id;


### PR DESCRIPTION
Some Discord guilds make use of _categories_ to further subdivide the
channels within the guild. This allows administrators to include this
category name into the room display name. This is escpecially
usefull, when multiple channels in the same guild have the same name
and are only differentiated by their category.

The discord.js API seems to suggest that categories could be
arbitrarily nested (as categories have a `parent` property, too), but
I could not find a way to create such nested categories in the Discord
UI. This change only exposes the category directly containing the
channel.