### PR TITLE
Fix incorrect package name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /opt/mx-puppet-discord
 # run build process as user in case of npm pre hooks
 # pre hooks are not executed while running as root
 RUN chown node:node /opt/mx-puppet-discord
-RUN apk --no-cache add git python make g++ pkgconfig \
+RUN apk --no-cache add git python3 make g++ pkgconfig \
     build-base \
     cairo-dev \
     jpeg-dev \


### PR DESCRIPTION
The package name used to add the Python package to the alpine container
is no longer correct. Changed to 'python3'.