### PR TITLE
Force node:alpine to node v12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:12-alpine AS builder
 
 WORKDIR /opt/mx-puppet-discord
 
@@ -33,7 +33,7 @@ COPY src/ ./src/
 RUN npm run build
 
 
-FROM node:alpine
+FROM node:12-alpine
 
 VOLUME /data
 


### PR DESCRIPTION
node:alpine now points to v16 which results in an error when trying to compile the docker image about not meeting requirements of a dependency.

When trying to compile the docker image today the attached error will occur. To resolve this we can simply clamp the node version to v12. Ultimately, it looks like the versioning on node is different which is causing it to be alarmed. Where previously it wasn't prefixed with a 'v' it now is. This is speculation though. :-) 

```
FROM node:12-alpine AS builder
(1/1) Installing glibc (2.32-r0)
OK: 386 MiB in 155 packages
Removing intermediate container 849dc5e11328
 ---> ef8c56e3fd63
Step 6/22 : COPY package.json package-lock.json ./
 ---> 51e797f5deee
Step 7/22 : RUN chown node:node package.json package-lock.json
 ---> Running in 79e395befe8a
Removing intermediate container 79e395befe8a
 ---> ba3e63351a15
Step 8/22 : USER node
 ---> Running in 82ff895cde7d
Removing intermediate container 82ff895cde7d
 ---> 2a4a45f4c6c0
Step 9/22 : RUN npm install
 ---> Running in 74e4886bf094
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@sorunome/matrix-bot-sdk@0.5.13',
npm WARN EBADENGINE   required: { node: '>=10.0.0', npm: '^6.0.0', yarn: '^1.19.0' },
npm WARN EBADENGINE   current: { node: 'v16.6.0', npm: '7.19.1' }
npm WARN EBADENGINE }
```