### PR TITLE
better looking url output for uploaded files from matrix to discord

### DIFF
--- a/src/matrix/MatrixEventHandler.ts
+++ b/src/matrix/MatrixEventHandler.ts
@@ -92,7 +92,7 @@ export class MatrixEventHandler {
 		}
 		try {
 			const filename = await this.app.discord.discordEscape(data.filename);
-			const msg = `Uploaded a file \`${filename}\`: ${data.url}`;
+			const msg = `${data.url}/${filename}`;
 			this.app.messageDeduplicator.lock(lockKey, p.client.user!.id, msg);
 			const reply = await this.app.discord.sendToDiscord(chan, msg, asUser);
 			await this.app.matrix.insertNewEventId(room, data.eventId!, reply);


### PR DESCRIPTION
This changes makes the file extension visible in Discord which is important for embedded videos up to 50MB without having to pay for their nitro subscription and still have the Discord people see videos directly embedded into the client.